### PR TITLE
Make startup.sh more robust

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
+set -euo pipefail
 # Using the technology of systemd to keep gofer service running even after system restarts
 # place a corresponding unit service file in your systemd unit path (/etc/systemd/system/ for most)
-source ~/gradingenv/bin/activate
-python gofer_nb.py
+source /home/vipasu/gradingenv/bin/activate
+exec python /home/vipasu/gofer_service/gofer_nb.py


### PR DESCRIPTION
- Fail whenever an error happens
- Use full path
- Use `exec` for executing final program